### PR TITLE
Pin title header in PWA

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -136,8 +136,9 @@
       function detectPWAMode() {
         const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
         const isAppleStandalone = ('standalone' in window.navigator) && window.navigator.standalone;
+        const isMinimalUI = window.matchMedia('(display-mode: minimal-ui)').matches;
         
-        if (isStandalone || isAppleStandalone) {
+        if (isStandalone || isAppleStandalone || isMinimalUI) {
           console.log('🚀 Running as PWA');
           document.body.classList.add('pwa-mode');
           
@@ -145,6 +146,21 @@
           if (isAppleStandalone) {
             document.body.classList.add('ios-pwa');
           }
+          
+          // Force header pinning for PWA mode
+          const style = document.createElement('style');
+          style.textContent = `
+            .pwa-mode header {
+              position: fixed !important;
+              top: 0 !important;
+              left: 0 !important;
+              right: 0 !important;
+              z-index: 9999 !important;
+              transform: translateZ(0) !important;
+              backface-visibility: hidden !important;
+            }
+          `;
+          document.head.appendChild(style);
         } else {
           console.log('🌐 Running in browser');
         }
@@ -210,6 +226,18 @@
       /* PWA-specific styles */
       .pwa-mode {
         /* Add any styling for when app runs as PWA */
+        overflow-x: hidden;
+      }
+      
+      /* Enhanced header pinning for PWA mode */
+      .pwa-mode header {
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        z-index: 9999 !important;
+        transform: translateZ(0) !important;
+        backface-visibility: hidden !important;
       }
       
       .ios-pwa {

--- a/client/src/components/ui/header.tsx
+++ b/client/src/components/ui/header.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { Avatar } from "@/components/ui/avatar";
 import { NavigationMenu } from "@/components/ui/navigation-menu";
 import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
 
 interface HeaderProps {
   title?: string;
@@ -11,12 +12,25 @@ interface HeaderProps {
   showHomeButton?: boolean;
 }
 
+// Utility function to detect PWA mode
+function isPWAMode(): boolean {
+  return window.matchMedia('(display-mode: standalone)').matches ||
+         window.matchMedia('(display-mode: window-controls-overlay)').matches ||
+         (window.navigator as any).standalone === true;
+}
+
 export function Header({ title, showBackButton = false, onBack, showHomeButton = false }: HeaderProps = {}) {
   const { user } = useAuth();
+  const [isPWA, setIsPWA] = useState(false);
+
+  useEffect(() => {
+    setIsPWA(isPWAMode());
+  }, []);
 
   return (
-    <header className="bg-white shadow-lg border-0 px-4 fixed top-0 left-0 right-0 z-50 
-      pt-[calc(env(safe-area-inset-top)+0.75rem)] pb-3 min-h-[calc(env(safe-area-inset-top)+4rem)]">
+    <header className={`bg-white shadow-lg border-0 px-4 fixed top-0 left-0 right-0 z-50 
+      pt-[calc(env(safe-area-inset-top)+0.75rem)] pb-3 min-h-[calc(env(safe-area-inset-top)+4rem)]
+      ${isPWA ? 'pwa-header-pinned' : ''}`}>
       <div className="flex items-center justify-between">
         {/* Left side - Back button or Navigation Menu */}
         <div className="flex items-center space-x-2">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -270,3 +270,58 @@
     transform: translateY(0);
   }
 }
+
+/* PWA-specific header pinning styles */
+.pwa-header-pinned {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  z-index: 9999 !important;
+  transform: translateZ(0) !important;
+  backface-visibility: hidden !important;
+  will-change: transform !important;
+  -webkit-transform: translateZ(0) !important;
+  -webkit-backface-visibility: hidden !important;
+}
+
+/* Ensure PWA mode has proper stacking context */
+@media (display-mode: standalone) {
+  header {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    z-index: 9999 !important;
+    transform: translateZ(0) !important;
+    backface-visibility: hidden !important;
+  }
+  
+  /* Force hardware acceleration for smooth scrolling */
+  .app-gradient-bg,
+  main {
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-perspective: 1000px;
+    perspective: 1000px;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
+}
+
+/* iOS standalone mode specific fixes */
+@supports (-webkit-touch-callout: none) {
+  @media (display-mode: standalone) {
+    .pwa-header-pinned {
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      -webkit-transform: translate3d(0, 0, 0) !important;
+      transform: translate3d(0, 0, 0) !important;
+      -webkit-backface-visibility: hidden !important;
+      backface-visibility: hidden !important;
+    }
+  }
+}


### PR DESCRIPTION
Fixes the PWA header not being pinned by enhancing PWA detection and applying PWA-specific CSS for fixed positioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ff2aa5b-2aa4-409d-88b0-b150361a9a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ff2aa5b-2aa4-409d-88b0-b150361a9a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

